### PR TITLE
Midi reconnect and channel aftertouch

### DIFF
--- a/musicEngine/midi/__init__.py
+++ b/musicEngine/midi/__init__.py
@@ -10,7 +10,7 @@ class Midi():
     self.midiOut = MidiOut()
     self.state = {
       'midiOutputConnected': False,
-      'midiOutputController': None,
+      'midiOutputControllerName': '',
       'midiOutputPortNumber': 1, # default
 
       'velocity': 100, # constant velocity or center of random distribution
@@ -43,7 +43,7 @@ class Midi():
     print(self.availableOutputPorts)
     if len(self.availableOutputPorts) > 1:
       self.midiOut.open_port(self.state['midiOutputPortNumber'])
-      self.state['midiOutputController'] = self.availableOutputPorts[self.state['midiOutputPortNumber']]
+      self.state['midiOutputControllerName'] = self.availableOutputPorts[self.state['midiOutputPortNumber']]
       self.state['midiOutputConnected'] = True
     asyncio.ensure_future(self.__loop())
 
@@ -65,6 +65,28 @@ class Midi():
     def setCCValue(value):
       self.state['CCValues'][cc] = math.floor(((value+1) / 2)*128)
     return setCCValue
+
+  async def __loop(self):
+    while True:
+      self.availableOutputPorts = self.midiOut.get_ports()
+      if self.state['midiOutputControllerName'] in self.availableOutputPorts:
+        self.__sendAfterTouch()
+        self.__sendCCValues()
+      else:
+        self.__reconnect()
+      await asyncio.sleep(MIDI_STEP)
+
+  def __reconnect(self):
+    if self.midiOut.is_port_open():
+      self.midiOut.close_port()
+      self.state['midiOutputConnected'] = False
+
+    if len(self.availableOutputPorts) > 1:
+      self.midiOut.open_port(self.state['midiOutputPortNumber'])
+      self.state['midiOutputControllerName'] = self.availableOutputPorts[self.state['midiOutputPortNumber']]
+      self.state['midiOutputConnected'] = True
+    else:
+      self.state['midiOutputControllerName'] = ''
 
   def __noteOff(self, note, player):
     noteChannel = self.__getNoteChannel(note, player, type)
@@ -164,28 +186,6 @@ class Midi():
           channelCommand = self.__combineCommandAndChannel(CONTROL_CHANGE, channel)
           self.midiOut.send_message([channelCommand, cc, val])  
         self.state['lastSentCCValues'][cc] = val
-
-  async def __loop(self):
-    while True:
-      if self.state['midiOutputController'] in self.midiOut.get_ports():
-        self.__sendAfterTouch()
-        self.__sendCCValues()
-      else:
-        self.__reconnect()
-      await asyncio.sleep(MIDI_STEP)
-
-  def __reconnect(self):
-    if self.midiOut.is_port_open():
-      self.midiOut.close_port()
-      self.state['midiOutputConnected'] = False
-
-    self.availableOutputPorts = self.midiOut.get_ports()
-    if len(self.availableOutputPorts) > 1:
-      self.midiOut.open_port(self.state['midiOutputPortNumber'])
-      self.state['midiOutputController'] = self.availableOutputPorts[self.state['midiOutputPortNumber']]
-      self.state['midiOutputConnected'] = True
-    else:
-      self.state['midiOutputController'] = None
   
   def __combineCommandAndChannel(self, command, channel):
     return ((command & 0xf0) | (channel & 0xf))

--- a/musicEngine/midi/__init__.py
+++ b/musicEngine/midi/__init__.py
@@ -10,6 +10,7 @@ class Midi():
     self.midiOut = MidiOut()
     self.state = {
       'midiOutputController': None,
+      'midiOutputPortNumber': 1, # default
       'velocity': 100, # constant velocity or center of random distribution
       'velocityMode': 'random', # 'constant' or 'random'
       'velocityDeviation': 15, # 'standard deviation for random velocity'
@@ -38,8 +39,8 @@ class Midi():
     self.availableOutputPorts = self.midiOut.get_ports()
     print(self.availableOutputPorts)
     if len(self.availableOutputPorts) > 1:
-      self.midiOut.open_port(1)
-      self.state['midiOutputController'] = self.availableOutputPorts[1]
+      self.midiOut.open_port(self.state['midiOutputPortNumber'])
+      self.state['midiOutputController'] = self.availableOutputPorts[self.state['midiOutputPortNumber']]
     asyncio.ensure_future(self.__loop())
 
   def handleMessage(self, message):
@@ -162,11 +163,12 @@ class Midi():
       await asyncio.sleep(MIDI_STEP)
 
   def __reconnect(self):
+    if self.midiOut.is_port_open(): self.midiOut.close_port()
     self.availableOutputPorts = self.midiOut.get_ports()
     print(self.availableOutputPorts)
     if len(self.availableOutputPorts) > 1:
-      self.midiOut.open_port(1)
-      self.state['midiOutputController'] = self.availableOutputPorts[1]
+      self.midiOut.open_port(self.state['midiOutputPortNumber'])
+      self.state['midiOutputController'] = self.availableOutputPorts[self.state['midiOutputPortNumber']]
     else:
       self.state['midiOutputController'] = None
   

--- a/musicEngine/midi/__init__.py
+++ b/musicEngine/midi/__init__.py
@@ -12,6 +12,7 @@ class Midi():
       'midiOutputConnected': False,
       'midiOutputController': None,
       'midiOutputPortNumber': 1, # default
+
       'velocity': 100, # constant velocity or center of random distribution
       'velocityMode': 'random', # 'constant' or 'random'
       'velocityDeviation': 15, # 'standard deviation for random velocity'
@@ -27,6 +28,7 @@ class Midi():
       'chordChannel': 0,
       'bassChannel': 0,
 
+      'usePolyphonicAfterTouch': False, # default is to use channel aftertouch
       'afterTouch': 0,
       'lastSentAfterTouch': 0,
       'CCValues': {},
@@ -148,7 +150,13 @@ class Midi():
         channelCommand = self.__combineCommandAndChannel(POLY_AFTERTOUCH, channel)
         self.midiOut.send_message([channelCommand, bassNote, self.state['afterTouch']])
       self.state['lastSentAfterTouch'] = self.state['afterTouch']
-        
+  
+  def __sendAfterTouch(self):
+    if self.state['usePolyphonicAfterTouch']:
+      self.__sendPolyphonicAftertouch()
+    else:
+      self.__sendChannelAfterTouch()
+
   def __sendCCValues(self):
     for cc, val in self.state['CCValues'].items():
       if val != self.state['lastSentCCValues'][cc]:
@@ -160,8 +168,7 @@ class Midi():
   async def __loop(self):
     while True:
       if self.state['midiOutputController'] in self.midiOut.get_ports():
-        # self.__sendPolyphonicAftertouch()
-        self.__sendChannelAfterTouch()
+        self.__sendAfterTouch()
         self.__sendCCValues()
       else:
         self.__reconnect()
@@ -173,7 +180,6 @@ class Midi():
       self.state['midiOutputConnected'] = False
 
     self.availableOutputPorts = self.midiOut.get_ports()
-    print(self.availableOutputPorts)
     if len(self.availableOutputPorts) > 1:
       self.midiOut.open_port(self.state['midiOutputPortNumber'])
       self.state['midiOutputController'] = self.availableOutputPorts[self.state['midiOutputPortNumber']]

--- a/musicEngine/midi/__init__.py
+++ b/musicEngine/midi/__init__.py
@@ -9,6 +9,7 @@ class Midi():
   def __init__(self):
     self.midiOut = MidiOut()
     self.state = {
+      'midiOutputConnected': False,
       'midiOutputController': None,
       'midiOutputPortNumber': 1, # default
       'velocity': 100, # constant velocity or center of random distribution
@@ -41,9 +42,13 @@ class Midi():
     if len(self.availableOutputPorts) > 1:
       self.midiOut.open_port(self.state['midiOutputPortNumber'])
       self.state['midiOutputController'] = self.availableOutputPorts[self.state['midiOutputPortNumber']]
+      self.state['midiOutputConnected'] = True
     asyncio.ensure_future(self.__loop())
 
   def handleMessage(self, message):
+    if not self.state['midiOutputConnected']:
+      return None
+
     note, player, type = message['note'], message['player'], message['type']
     if type == 'on':
       self.__noteOn(note, player)
@@ -163,12 +168,16 @@ class Midi():
       await asyncio.sleep(MIDI_STEP)
 
   def __reconnect(self):
-    if self.midiOut.is_port_open(): self.midiOut.close_port()
+    if self.midiOut.is_port_open():
+      self.midiOut.close_port()
+      self.state['midiOutputConnected'] = False
+
     self.availableOutputPorts = self.midiOut.get_ports()
     print(self.availableOutputPorts)
     if len(self.availableOutputPorts) > 1:
       self.midiOut.open_port(self.state['midiOutputPortNumber'])
       self.state['midiOutputController'] = self.availableOutputPorts[self.state['midiOutputPortNumber']]
+      self.state['midiOutputConnected'] = True
     else:
       self.state['midiOutputController'] = None
   

--- a/musicEngine/midi/__init__.py
+++ b/musicEngine/midi/__init__.py
@@ -9,6 +9,7 @@ class Midi():
   def __init__(self):
     self.midiOut = MidiOut()
     self.state = {
+      'midiOutputController': None,
       'velocity': 100, # constant velocity or center of random distribution
       'velocityMode': 'random', # 'constant' or 'random'
       'velocityDeviation': 15, # 'standard deviation for random velocity'
@@ -36,8 +37,9 @@ class Midi():
   def start(self):
     self.availableOutputPorts = self.midiOut.get_ports()
     print(self.availableOutputPorts)
-    if len(self.availableOutputPorts) > 0:
+    if len(self.availableOutputPorts) > 1:
       self.midiOut.open_port(1)
+      self.state['midiOutputController'] = self.availableOutputPorts[1]
     asyncio.ensure_future(self.__loop())
 
   def handleMessage(self, message):
@@ -112,7 +114,7 @@ class Midi():
     if self.state['afterTouch'] == self.state['lastSentAfterTouch']:
       return None
 
-    aftertouchValue = self.state['afterTouch'] # & 0x7F
+    aftertouchValue = self.state['afterTouch']
     channel = self.state['distChordChannels'][note] if self.state['distributeChannels'] else self.state['chordChannel']
     channelCommand = self.__combineCommandAndChannel(CHANNEL_PRESSURE, channel)
     self.midiOut.send_message([channelCommand, aftertouchValue])
@@ -124,7 +126,7 @@ class Midi():
 
     self.state['lastSentAfterTouch'] = self.state['afterTouch']
 
-  def __sendAftertouch(self):
+  def __sendPolyphonicAftertouch(self):
     if self.state['afterTouch'] != self.state['lastSentAfterTouch']:
       for note in self.state['playingChordNotes']:
         channel = self.state['chordChannel']
@@ -151,8 +153,8 @@ class Midi():
 
   async def __loop(self):
     while True:
-      if self.midiOut.is_port_open:
-        # self.__sendAftertouch()
+      if self.state['midiOutputController'] in self.midiOut.get_ports():
+        # self.__sendPolyphonicAftertouch()
         self.__sendChannelAfterTouch()
         self.__sendCCValues()
       else:
@@ -162,8 +164,11 @@ class Midi():
   def __reconnect(self):
     self.availableOutputPorts = self.midiOut.get_ports()
     print(self.availableOutputPorts)
-    if len(self.availableOutputPorts) > 0:
+    if len(self.availableOutputPorts) > 1:
       self.midiOut.open_port(1)
+      self.state['midiOutputController'] = self.availableOutputPorts[1]
+    else:
+      self.state['midiOutputController'] = None
   
   def __combineCommandAndChannel(self, command, channel):
     return ((command & 0xf0) | (channel & 0xf))

--- a/musicEngine/midi/__init__.py
+++ b/musicEngine/midi/__init__.py
@@ -108,6 +108,22 @@ class Midi():
     elif player == 'bass':
       return self.state['bassChannel']
 
+  def __sendChannelAfterTouch(self):
+    if self.state['afterTouch'] == self.state['lastSentAfterTouch']:
+      return None
+
+    aftertouchValue = self.state['afterTouch'] # & 0x7F
+    channel = self.state['distChordChannels'][note] if self.state['distributeChannels'] else self.state['chordChannel']
+    channelCommand = self.__combineCommandAndChannel(CHANNEL_PRESSURE, channel)
+    self.midiOut.send_message([channelCommand, aftertouchValue])
+
+    if self.state['playingBassNote']:
+      channel = self.state['distBassChannel'] if self.state['distributeChannels'] else self.state['bassChannel']
+      channelCommand = self.__combineCommandAndChannel(CHANNEL_PRESSURE, channel)
+      self.midiOut.send_message([channelCommand, aftertouchValue])
+
+    self.state['lastSentAfterTouch'] = self.state['afterTouch']
+
   def __sendAftertouch(self):
     if self.state['afterTouch'] != self.state['lastSentAfterTouch']:
       for note in self.state['playingChordNotes']:
@@ -135,9 +151,19 @@ class Midi():
 
   async def __loop(self):
     while True:
-      self.__sendAftertouch()
-      self.__sendCCValues()
+      if self.midiOut.is_port_open:
+        # self.__sendAftertouch()
+        self.__sendChannelAfterTouch()
+        self.__sendCCValues()
+      else:
+        self.__reconnect()
       await asyncio.sleep(MIDI_STEP)
+
+  def __reconnect(self):
+    self.availableOutputPorts = self.midiOut.get_ports()
+    print(self.availableOutputPorts)
+    if len(self.availableOutputPorts) > 0:
+      self.midiOut.open_port(1)
   
   def __combineCommandAndChannel(self, command, channel):
     return ((command & 0xf0) | (channel & 0xf))


### PR DESCRIPTION
Refactored some of the code, added the ability to reconnect to midi device at any point and made a flag for using channel aftertouch as default vs polyphonic aftertouch.